### PR TITLE
No dropdowns when virtual hosting a sub site at the navigation root

### DIFF
--- a/src/webcouturier/dropdownmenu/browser/dropdown.py
+++ b/src/webcouturier/dropdownmenu/browser/dropdown.py
@@ -120,7 +120,8 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
             'enable_caching', False)
         self.enable_parent_clickable = self.dropdown_properties.getProperty(
             'enable_parent_clickable', True)
-        self.data = Assignment(root=getNavigationRoot(self.context))
+        self.navroot_path = getNavigationRoot(self.context)
+        self.data = Assignment(root=self.navroot_path)
 
     def getTabObject(self, tabUrl='', tabPath=None):
         if tabUrl == self.portal_state.navigation_root_url():
@@ -156,6 +157,12 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
             return ''
 
         portal = self.portal_state.portal()
+        portal_path = '/'.join(portal.getPhysicalPath())
+        # Check to see if we are using a navigation root. If we are
+        # virtual hosting the navigation root as its own domain,
+        # the tabPath is no longer rooted at the main portal.
+        if portal_path != self.navroot_path:
+            portal = portal.restrictedTraverse(self.navroot_path)
         tabObj = portal.restrictedTraverse(tabPath, None)
 
         if tabObj is None:


### PR DESCRIPTION
When you use Virtual Host Monster to serve up a sub site as its own domain, the tabPath no longer relates to the main portal. If you have a Plone site like this:

```
Plone
├── subsite1
│   ├── folder1
│   │   ├── page1
│   │   └── page2
│   └── folder2
└── subsite2
```

Then set up a VHM rewrite like this:

```
RewriteRule ^/(.*)$ http://localhost:8080/VirtualHostBase/http/subsite1.example.com:80/Plone/subsite1/VirtualHostRoot/$1 [L,P]
```

The `folder1` menu item would not expand because it would be trying to do this:

```
portal.restrictedTraverse('folder1')
```
