### PR TITLE
Restore the hasDropDown link class

### DIFF
--- a/src/webcouturier/dropdownmenu/browser/dropdown.py
+++ b/src/webcouturier/dropdownmenu/browser/dropdown.py
@@ -120,7 +120,8 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
             'enable_caching', False)
         self.enable_parent_clickable = self.dropdown_properties.getProperty(
             'enable_parent_clickable', True)
-        self.data = Assignment(root=getNavigationRoot(self.context))
+        self.navroot_path = getNavigationRoot(self.context)
+        self.data = Assignment(root=self.navroot_path)
 
     def getTabObject(self, tabUrl='', tabPath=None):
         if tabUrl == self.portal_state.navigation_root_url():
@@ -156,6 +157,12 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
             return ''
 
         portal = self.portal_state.portal()
+        portal_path = '/'.join(portal.getPhysicalPath())
+        # Check to see if we are using a navigation root. If we are
+        # virtual hosting the navigation root as its own domain,
+        # the tabPath is no longer rooted at the main portal.
+        if portal_path != self.navroot_path:
+            portal = portal.restrictedTraverse(self.navroot_path)
         tabObj = portal.restrictedTraverse(tabPath, None)
 
         if tabObj is None:

--- a/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
@@ -17,8 +17,9 @@
                 normalizeString nocall: context/plone_utils/normalizeString;"
     tal:condition="python:bottomLevel &lt;= 0 or level &lt;= bottomLevel">
 
-    <tal:level define="item_class string:state-${node/normalized_review_state};
-                       has_children nocall:children;
+    <tal:level define="has_children nocall:children;
+                       children_class python:has_children and ' hasDropDown' or '';
+                       item_class string:state-${node/normalized_review_state}${children_class};
                        item_clickable python:enable_parent_clickable or not has_children;">
 
         <a tal:attributes="href python:item_url;


### PR DESCRIPTION
needed for sub menu arrows which  was, I assume accidentally, in:   0be17188f61ee13a0e0254aaae288075dd8de274
