### PR TITLE
Plone3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Changelog
 webcouturier.dropdownmenu 2.3 unreleased
 -----------------------------------------------
 
+- Only load the CMF permissions when on Plone 4.1 or higher.
+  [maurits]
+
 - fix unkown version in quickinstaller.
   [toutpt]
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ Changelog
 webcouturier.dropdownmenu 2.3 unreleased
 -----------------------------------------------
 
+- Moved the plone.app.testing and unittest2 dependencies to a test
+  extra.
+  [Maurits]
+
 - Only load the CMF permissions when on Plone 4.1 or higher.
   [maurits]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-4.1.x.cfg
 package-name = webcouturier.dropdownmenu
-
+test-eggs = webcouturier.dropdownmenu[test]
 parts+=omelette
 
 [omelette]
@@ -10,7 +10,8 @@ eggs=${instance:eggs}
 
 [test]
 recipe = collective.xmltestreport
+defaults = ['-v', '-s', '${buildout:package-name}']
 eggs =
-    webcouturier.dropdownmenu
+    ${buildout:package-name}
     ${instance:eggs}
-
+    ${buildout:test-eggs}

--- a/buildout3.cfg
+++ b/buildout3.cfg
@@ -1,7 +1,7 @@
 [buildout]
 extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-3.x.cfg
 package-name = webcouturier.dropdownmenu
-
+test-eggs = webcouturier.dropdownmenu[test]
 parts+=omelette
 versions = versions
 
@@ -18,7 +18,8 @@ eggs=${instance:eggs}
 
 [test]
 recipe = collective.xmltestreport
+defaults = ['-v', '-s', '${buildout:package-name}']
 eggs =
-    webcouturier.dropdownmenu
+    ${buildout:package-name}
     ${instance:eggs}
-
+    ${buildout:test-eggs}

--- a/buildout3.cfg
+++ b/buildout3.cfg
@@ -1,0 +1,24 @@
+[buildout]
+extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-3.x.cfg
+package-name = webcouturier.dropdownmenu
+
+parts+=omelette
+versions = versions
+
+[versions]
+# For Plone 3:
+Products.CMFPlone = 4.0b1
+plone.app.testing = 3.0a1
+plone.testing = 3.0a2
+unittest2 = 0.5.1
+
+[omelette]
+recipe=collective.recipe.omelette
+eggs=${instance:eggs}
+
+[test]
+recipe = collective.xmltestreport
+eggs =
+    webcouturier.dropdownmenu
+    ${instance:eggs}
+

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,13 @@ setup(name='webcouturier.dropdownmenu',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          'plone.app.testing',
-          'unittest2',
           'plone.browserlayer',
       ],
+      extras_require={
+          'test': ['plone.app.testing',
+                   'unittest2',
+                   ],
+      },
       entry_points="""
       [z3c.autoinclude.plugin]
       target = plone

--- a/src/webcouturier/dropdownmenu/browser/dropdown.py
+++ b/src/webcouturier/dropdownmenu/browser/dropdown.py
@@ -65,7 +65,7 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
 
         return ''.join((
             self.selected_portal_tab,
-            get_language(aq_inner(self.context), self.request),
+            get_language(context, self.request),
             str(anonymous),
         ))
 
@@ -113,14 +113,15 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
     def update(self):
         common.ViewletBase.update(self)  # Get portal_state and portal_url
         super(DropdownMenuViewlet, self).update()
-        portal_props = getToolByName(self.context, 'portal_properties')
+        context = aq_inner(self.context)
+        portal_props = getToolByName(context, 'portal_properties')
         self.properties = portal_props.navtree_properties
         self.dropdown_properties = portal_props.dropdown_properties
         self.enable_caching = self.dropdown_properties.getProperty(
             'enable_caching', False)
         self.enable_parent_clickable = self.dropdown_properties.getProperty(
             'enable_parent_clickable', True)
-        self.navroot_path = getNavigationRoot(self.context)
+        self.navroot_path = getNavigationRoot(context)
         self.data = Assignment(root=self.navroot_path)
 
     def getTabObject(self, tabUrl='', tabPath=None):

--- a/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
+++ b/src/webcouturier/dropdownmenu/browser/dropdown_recurse.pt
@@ -28,7 +28,7 @@
             <img tal:replace="structure item_icon/html_tag" />
             <span tal:replace="node/Title">Selected Item Title</span>
         </a>
-        
+
         <ul tal:attributes="class python:'submenu navTree navTreeLevel'+str(level)"
             tal:condition="python: len(children) > 0 and show_children">
             <span tal:replace="structure python:view.recurse(children=children, level=level+1, bottomLevel=bottomLevel)" />

--- a/src/webcouturier/dropdownmenu/configure.zcml
+++ b/src/webcouturier/dropdownmenu/configure.zcml
@@ -8,7 +8,9 @@
     <five:registerPackage package="." initialize=".initialize" />
 
     <include package="plone.browserlayer" />
-    <include package="Products.CMFCore" file="permissions.zcml" />
+    <include package="Products.CMFCore" file="permissions.zcml"
+             xmlns:zcml="http://namespaces.zope.org/zcml"
+             zcml:condition="have plone-41" />
 
     <include package=".browser" />
 

--- a/src/webcouturier/dropdownmenu/tests/browser.txt
+++ b/src/webcouturier/dropdownmenu/tests/browser.txt
@@ -20,7 +20,7 @@ Let us get the absolute url of our website and try to load that with
 the testbrowser.
 
     >>> browser.open(portal.absolute_url())
-    >>> 'Welcome to Plone' in browser.contents
+    >>> '"documentFirstHeading">Plone site' in browser.contents or 'Welcome to Plone' in browser.contents
     True
 
 
@@ -66,7 +66,7 @@ allows us to get to the children.
 Now we try again.
 
     >>> browser.open(portal.absolute_url())
-    >>> 'Welcome to Plone' in browser.contents
+    >>> '"documentFirstHeading">Plone site' in browser.contents or 'Welcome to Plone' in browser.contents
     True
 
 This time, the link to the folder should have a special class 'noClick' in

--- a/src/webcouturier/dropdownmenu/tests/browser.txt
+++ b/src/webcouturier/dropdownmenu/tests/browser.txt
@@ -20,7 +20,7 @@ Let us get the absolute url of our website and try to load that with
 the testbrowser.
 
     >>> browser.open(portal.absolute_url())
-    >>> '"documentFirstHeading">Plone site' in browser.contents
+    >>> 'Welcome to Plone' in browser.contents
     True
 
 
@@ -66,7 +66,7 @@ allows us to get to the children.
 Now we try again.
 
     >>> browser.open(portal.absolute_url())
-    >>> '"documentFirstHeading">Plone site' in browser.contents
+    >>> 'Welcome to Plone' in browser.contents
     True
 
 This time, the link to the folder should have a special class 'noClick' in

--- a/src/webcouturier/dropdownmenu/tests/layer.py
+++ b/src/webcouturier/dropdownmenu/tests/layer.py
@@ -46,18 +46,21 @@ class DropdownmenuLayer(DropdownmenuBasicLayer):
         for i in range(2):
             folder_id = 'folder-%s' % i
             portal.invokeFactory('Folder', folder_id)
+            getattr(portal, folder_id).reindexObject()
 
         # now we add some subfolders to one of the folders
         folder_one = getattr(portal, 'folder-0')
         for i in range(2):
             folder_id = 'sub-%s' % i
             folder_one.invokeFactory('Folder', folder_id)
+            getattr(folder_one, folder_id).reindexObject()
 
         # And some sub-sub folders
         subfolder = getattr(folder_one, 'sub-0')
         for i in range(2):
             folder_id = 'sub-sub-%s' % i
             subfolder.invokeFactory('Folder', folder_id)
+            getattr(subfolder, folder_id).reindexObject()
 
         setRoles(portal, TEST_USER_ID, ['Member'])
 

--- a/src/webcouturier/dropdownmenu/upgrades.zcml
+++ b/src/webcouturier/dropdownmenu/upgrades.zcml
@@ -2,7 +2,7 @@
   xmlns="http://namespaces.zope.org/zope"
   xmlns:gs="http://namespaces.zope.org/genericsetup"
   i18n_domain="collective.gallery">
-        
+
   <gs:upgradeStep
     title="Upgrade webcouturier.dropdownmenu 1000"
     description=""


### PR DESCRIPTION
This should fix compatibility with Plone 3.  It also moves plone.app.testing and unittest2 to a extra test dependency, so these packages are not pulled in by default when you just want to use the package.

On Plone 3 manual testing with several levels and a navigation root goes fine as far as I see. Two tests fail though.  I guess this is only a testing problem; no idea how to fix it though.

The complete traceback is really too long. It boils down to `Unauthorized: You are not allowed to access 'recurse' in this context`.  This happens in the two tests of `webcouturier.dropdownmenu.tests.test_integration.TestINavigationRootDropdownmenu`.  I tried fixing it but failed.  But like I said, all seems to go fine in manual testing, also as anonymous user.
