### PR TITLE
Does not work in combination with plone.app.multilingual 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ webcouturier.dropdownmenu 2.3 unreleased
 
 - fix unkown version in quickinstaller.
   [toutpt]
+  
+- Fix according plone.app.multilingual
+  [pabo3000]
 
 webcouturier.dropdownmenu 2.2 (August 17, 2011)
 -----------------------------------------------

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,10 @@
 [buildout]
-extends = http://svn.plone.org/svn/collective/buildout/plonetest/test-4.1.x.cfg
+extends = https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
 package-name = webcouturier.dropdownmenu
 test-eggs = webcouturier.dropdownmenu[test]
 parts+=omelette
+
+versions = versions
 
 [omelette]
 recipe=collective.recipe.omelette
@@ -15,3 +17,6 @@ eggs =
     ${buildout:package-name}
     ${instance:eggs}
     ${buildout:test-eggs}
+    
+[versions]
+docutils = 0.11

--- a/src/webcouturier/dropdownmenu/browser/dropdown.py
+++ b/src/webcouturier/dropdownmenu/browser/dropdown.py
@@ -132,7 +132,7 @@ class DropdownMenuViewlet(common.GlobalSectionsViewlet):
             # get path for current tab's object
             try:
                 # we are in Plone > 3.0.x
-                tabPath = tabUrl.split(self.site_url)[-1]
+                tabPath = tabUrl.split(self.portal_state.navigation_root_url())[-1]
             except AttributeError:
                 # we are in Plone 3.0.x world
                 tabPath = tabUrl.split(self.portal_url)[-1]


### PR DESCRIPTION
If you combine webcouturier.dropdownmenu and plone.app.multilingual you would expect dropdownmenus in each LanguageRootFolder. But there is none.

Let us assume there are two languages 'de' and 'en'. in webcouturier.dropdownmenu.browser.dropdown is calculated a tabObj. 
A debug session gives the value: /plone/de/de/my-tab.
That is wrong. If you drop the second 'de' it works.

imo the tabPath should be calculated in the following way because in self.site_url is not taken into consideration that the Root is in the LanguageRootFolder.

```
tabPath = tabUrl.split(self.portal_state.navigation_root_url())[-1]
```

but not 

```
tabPath = tabUrl.split(self.site_url)[-1]
```
